### PR TITLE
Add Swift version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Swift interop from Frida.
 
 ## Requirements
 
-- Currently supports arm64(e) Darwin only
-- Tested apps must be build using Swift 5.0+
+- arm64(e) Darwin platforms
+- Apps built using Swift 5.0+
 
 ## Getting started
 The bridge comes bundled with Frida as of v15.1.0. That means it's as simple as [installing Frida](https://frida.re/docs/installation/), then:


### PR DESCRIPTION
Hi 👋 ,

Thanks for great tool 👏 
While I was using it I saw that bridge works only for apps with Swift 5.0+.
I believe it is due to missing function `swift_stdlib_getTypeByMangledNameUntrusted` inside previous versions of `libswiftCore.dylib`.
Which results in throwing error inside https://github.com/frida/frida-swift-bridge/blob/master/lib/api.ts