### PR TITLE
protocols: Handle the case when a weak protocol descriptor symbol is undefined

### DIFF
--- a/lib/macho.ts
+++ b/lib/macho.ts
@@ -23,8 +23,8 @@ interface ProtocolDescriptorMap {
 
 export interface ProtocolConformance {
     /**
-     * A protocol that's defined externally might be undefined when it's imported as a weak symbol, e.g. for
-     * backward compatability. This field will be null in that case to reflect that fact.
+     * An externally-defined protocol that's imported as a weak symbol (e.g. for backward compatibility) might be
+     * undefined on some systems. This field will be null in that case to reflect that fact.
      */
     protocol: TargetProtocolDescriptor | null;
     witnessTable: NativePointer;

--- a/lib/macho.ts
+++ b/lib/macho.ts
@@ -243,7 +243,7 @@ function bindProtocolConformances(module: Module) {
 
         if (conformanceDesc.protocol.isNull()) {
             /* Since we can't read the protocol's name via its conformance descriptor, we try to extract it via the
-            conformance descritpor's symbol. */
+            conformance descriptor's symbol. */
             const mangledSymbol = demangledSymbolFromAddress(descPtr);
             const protocolName = findProtocolNameInConformanceDescriptor(mangledSymbol);
 

--- a/lib/macho.ts
+++ b/lib/macho.ts
@@ -247,7 +247,7 @@ function bindProtocolConformances(module: Module) {
             const mangledSymbol = demangledSymbolFromAddress(descPtr);
             const protocolName = findProtocolNameInConformanceDescriptor(mangledSymbol);
 
-            if (protocolName == null) {
+            if (protocolName === null) {
                 console.warn(`Failed to parse protocol name from conformance descriptor '${mangledSymbol}'. Please file a bug.`);
                 continue;
             }

--- a/lib/macho.ts
+++ b/lib/macho.ts
@@ -10,7 +10,7 @@ import {
 import { ContextDescriptorKind } from "../abi/metadatavalues";
 import { getPrivateAPI } from "./api";
 import { RelativeDirectPointer } from "../basic/relativepointer";
-import { demangledSymbolFromAddress } from "./symbols";
+import { demangledSymbolFromAddress, findProtocolNameInConformanceDescriptor } from "./symbols";
 
 interface MachOSection {
     vmAddress: NativePointer;
@@ -22,7 +22,11 @@ interface ProtocolDescriptorMap {
 }
 
 export interface ProtocolConformance {
-    protocol: TargetProtocolDescriptor;
+    /**
+     * A protocol that's defined externally might be undefined when it's imported as a weak symbol, e.g. for
+     * backward compatability. This field will be null in that case to reflect that fact.
+     */
+    protocol: TargetProtocolDescriptor | null;
     witnessTable: NativePointer;
 }
 
@@ -218,9 +222,6 @@ function bindProtocolConformances(module: Module) {
         );
         const typeDescPtr = conformanceDesc.getTypeDescriptor();
         const typeDesc = new TargetTypeContextDescriptor(typeDescPtr);
-        const protocolDesc = new TargetProtocolDescriptor(
-            conformanceDesc.protocol
-        );
 
         /** TODO:
          *  - Handle ObjC case explicitly
@@ -239,12 +240,28 @@ function bindProtocolConformances(module: Module) {
         if (type === undefined) {
             continue;
         }
-        const conformance = {
-            protocol: protocolDesc,
-            witnessTable: conformanceDesc.witnessTablePattern,
-        };
 
-        type.conformances[protocolDesc.name] = conformance;
+        if (conformanceDesc.protocol.isNull()) {
+            const mangledSymbol = demangledSymbolFromAddress(descPtr);
+            const protocolName = findProtocolNameInConformanceDescriptor(mangledSymbol);
+
+            if (protocolName == null) {
+                console.warn(`Failed to parse protocol name from conformance descriptor '${mangledSymbol}'. Please file a bug.`);
+                continue;
+            }
+
+            type.conformances[protocolName] = {
+                protocol: null,
+                witnessTable: null,
+            };
+        } else {
+            const protocolDesc = new TargetProtocolDescriptor(conformanceDesc.protocol);
+
+            type.conformances[protocolDesc.name] = {
+                protocol: protocolDesc,
+                witnessTable: conformanceDesc.witnessTablePattern,
+            };
+        }
     }
 }
 

--- a/lib/macho.ts
+++ b/lib/macho.ts
@@ -242,6 +242,8 @@ function bindProtocolConformances(module: Module) {
         }
 
         if (conformanceDesc.protocol.isNull()) {
+            /* Since we can't read the protocol's name via its conformance descriptor, we try to extract it via the
+            conformance descritpor's symbol. */
             const mangledSymbol = demangledSymbolFromAddress(descPtr);
             const protocolName = findProtocolNameInConformanceDescriptor(mangledSymbol);
 

--- a/lib/symbols.ts
+++ b/lib/symbols.ts
@@ -238,7 +238,7 @@ export function findProtocolNameInConformanceDescriptor(conformance: string): st
     const regex = /protocol conformance descriptor for \S+ : \S+\.(\S+) in \S+/g;
     const matches = regex.exec(conformance);
 
-    if (matches == null || matches.length != 2) {
+    if (matches === null || matches.length != 2) {
         return null;
     }
 

--- a/lib/symbols.ts
+++ b/lib/symbols.ts
@@ -238,7 +238,7 @@ export function findProtocolNameInConformanceDescriptor(conformance: string): st
     const regex = /protocol conformance descriptor for \S+ : \S+\.(\S+) in \S+/g;
     const matches = regex.exec(conformance);
 
-    if (matches === null || matches.length != 2) {
+    if (matches === null) {
         return null;
     }
 

--- a/lib/symbols.ts
+++ b/lib/symbols.ts
@@ -234,6 +234,17 @@ export function getSymbolicator(): CSSymbolicator {
     return symbolicator;
 }
 
+export function findProtocolNameInConformanceDescriptor(conformance: string): string | null {
+    const regex = /protocol conformance descriptor for \S+ : \S+\.(\S+) in \S+/g;
+    const matches = regex.exec(conformance);
+
+    if (matches == null || matches.length != 2) {
+        return null;
+    }
+
+    return matches[1];
+}
+
 function releaseSymbolicator() {
     getPrivateAPI().CSRelease(cachedSymbolicator);
 }


### PR DESCRIPTION
**Background**
An externally-defined protocol that's imported as a weak symbol (e.g. for backward compatibility) might be undefined on some systems. Currently the bridge would crash in this case since it's trying to dereference a null pointer.

**Changes**
- Add an internal API for extracting a protocol name from its demangled conformance descriptor name.
- Handle a null protocol descriptor pointer.

**How it was tested**
A hello-world SwiftUI app built using Xcode 15.0 (15A240d) on macOS 13.5.2 that was crashing before this change.