### PR TITLE
Fix for error in iOS simulator

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -49,7 +49,7 @@ export function getPrivateAPI(): Api {
 
     Module.ensureInitialized("CoreFoundation");
 
-    if (Process.findModuleByName("CoreSymbolication") == null) {
+    if (Process.findModuleByName("CoreSymbolication") === null) {
         try {
             Module.load("/System/Library/PrivateFrameworks/CoreSymbolication.framework/CoreSymbolication");
         } catch (e) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -49,10 +49,12 @@ export function getPrivateAPI(): Api {
 
     Module.ensureInitialized("CoreFoundation");
 
-    try {
-        Module.load("/System/Library/PrivateFrameworks/CoreSymbolication.framework/CoreSymbolication");
-    } catch (e) {
-        Module.load("/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication");
+    if (Process.findModuleByName("CoreSymbolication") == null) {
+        try {
+            Module.load("/System/Library/PrivateFrameworks/CoreSymbolication.framework/CoreSymbolication");
+        } catch (e) {
+            Module.load("/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication");
+        }
     }
 
     cachedPrivateAPI = makeAPI([


### PR DESCRIPTION
When trying to use in the iOS simulator (17.4, arm64), it fails because it can't load `CoreSymbolication` from the expected paths:

```
frida --host localhost Gadget -l ~/Documents/Projects/iPhone/Frida/frida-swift-bridge/_agent.js
     ____
    / _  |   Frida 16.2.1 - A world-class dynamic instrumentation toolkit
   | (_| |
    > _  |   Commands:
   /_/ |_|       help      -> Displays the help system
   . . . .       object?   -> Display information about 'object'
   . . . .       exit/quit -> Exit
   . . . .
   . . . .   More info at https://frida.re/docs/home/
   . . . .
   . . . .   Connected to localhost (id=socket@localhost)
                                                                                
Error: dlopen(/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication, 0x0001): tried: '/Users/user/Library/Developer/Xcode/DerivedData/TestApp-apgxxwadlhbgphtscjjkfdhfsniq/Build/Products/Debug-iphonesimulator/CoreSymbolication.framework/Versions/A/CoreSymbolication' (no such file), '/Library/Developer/CoreSimulator/Volumes/iOS_21E213/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.4.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication' (no such file), '/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication' (no such file, no dyld cache), '/Library/Developer/CoreSimulator/Volumes/iOS_21E213/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.4.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication' (no such file)
    at value (frida/runtime/core.js:234)
    at getPrivateAPI (dist/lib/api.js:47)
    at getMachoSection (dist/lib/macho.js:193)
    at getSwift5TypesSection (dist/lib/macho.js:180)
    at enumerateTypeDescriptors (dist/lib/macho.js:93)
    at <anonymous> (dist/lib/macho.js:16)
    at call (native)
    at o (node_modules/browser-pack/_prelude.js:1)
    at <anonymous> (node_modules/browser-pack/_prelude.js:1)
    at <anonymous> (dist/lib/callingconvention.js:25)
    at call (native)
    at o (node_modules/browser-pack/_prelude.js:1)
    at <anonymous> (node_modules/browser-pack/_prelude.js:1)
    at <anonymous> (dist/lib/types.js:24)
    at call (native)
    at o (node_modules/browser-pack/_prelude.js:1)
    at <anonymous> (node_modules/browser-pack/_prelude.js:1)
    at <anonymous> (dist/index.js:25)
    at call (native)
    at o (node_modules/browser-pack/_prelude.js:1)
    at <anonymous> (node_modules/browser-pack/_prelude.js:1)
    at <anonymous> (loader.js:1)
    at call (native)
    at <anonymous> (/Users/user/Documents/Projects/iPhone/Frida/frida-swift-bridge/_agent.js:2887)
    at call (native)
    at <anonymous> (/Users/user/Documents/Projects/iPhone/Frida/frida-swift-bridge/_agent.js:2887)
    at call (native)
    at o (node_modules/browser-pack/_prelude.js:1)
    at r (node_modules/browser-pack/_prelude.js:1)
    at <eval> (/Users/user/Documents/Projects/iPhone/Frida/frida-swift-bridge/_agent.js:2889)
[Remote::Gadget ]-> Process.findModuleByName('CoreSymbolication')
{
    "base": "0x1142ac000",
    "name": "CoreSymbolication",
    "path": "/Library/Developer/CoreSimulator/Volumes/iOS_21E213/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.4.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CoreSymbolication.framework/CoreSymbolication",
    "size": 1081344
}
[Remote::Gadget ]->
```

The exception comes from inside the catch [here](https://github.com/frida/frida-swift-bridge/blob/6383765af0210a15ee245c8c5d0c96d8fd3e170c/lib/api.ts#L53) shows it tries some paths, but not the correct one:
```
Error: dlopen(/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication, 0x0001): tried: 
'/Users/user/Library/Developer/Xcode/DerivedData/TestApp-apgxxwadlhbgphtscjjkfdhfsniq/Build/Products/Debug-iphonesimulator/CoreSymbolication.framework/Versions/A/CoreSymbolication' (no such file), 
'/Library/Developer/CoreSimulator/Volumes/iOS_21E213/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.4.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication' (no such file), 
'/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication' (no such file, no dyld cache), 
'/Library/Developer/CoreSimulator/Volumes/iOS_21E213/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.4.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication' (no such file)
```

However when trying to load from the first path, it doesn't mention trying anything, the error doesn't come from dlopen:

```
[Remote::Gadget ]-> Module.load("/System/Library/PrivateFrameworks/CoreSymbolication.framework/CoreSymbolication")
Error: unable to find module '/System/Library/PrivateFrameworks/CoreSymbolication.framework/CoreSymbolication'
    at value (frida/runtime/core.js:356)
    at value (frida/runtime/core.js:234)
    at <eval> (<input>:1)
```

It  turns out the call to [Module._load](https://github.com/frida/frida-gum/blob/28257ab76cb61fb659e4331e4195e3a3faec9c2a/bindings/gumjs/runtime/core.js#L293-L294) succeeds, but `Process.getModuleByName` fails to find the module with that absolute path (the actual path is prefixed by `/Library/Developer/CoreSimulator/Volumes/iOS_21E213/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.4.simruntime/Contents/Resources/RuntimeRoot/`, which will vary by iOS version).

I've implemented a quick hack to get around this: `CoreSymbolication` seems to always be loaded when running apps in the iOS simulator, so loading it can be skipped if it's already there. Another hack could be to use the private `Module._load` instead.

A more proper solution might be something around `Module.load`, `Process.getModuleByName` or `gum_store_module_if_name_matches`, making it aware that `dlopen` can succeed when called with an absolute path, but the loaded module's path may be different.